### PR TITLE
feat: Add Todo Download Functionality

### DIFF
--- a/src/main/java/com/ttn/controller/TodoController.java
+++ b/src/main/java/com/ttn/controller/TodoController.java
@@ -1,66 +1,68 @@
 package com.ttn.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.ttn.model.Todo;
-import com.ttn.repository.TodoRepository;
-
-import java.util.List;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import com.ttn.service.TodoService;
 
 @RestController
 @RequestMapping("/api/todos")
 @CrossOrigin(origins = "*")
 public class TodoController {
 
+    private final TodoService todoService;
+
     @Autowired
-    private TodoRepository todoRepository;
+    public TodoController(TodoService todoService) {
+        this.todoService = todoService;
+    }
 
     @GetMapping
     public List<Todo> getAllTodos() {
-        return todoRepository.findAll();
+        return todoService.getAllTodos();
     }
 
     @PostMapping
     public Todo createTodo(@RequestBody Todo todo) {
-        return todoRepository.save(todo);
+        return todoService.createTodo(todo);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Todo> getTodoById(@PathVariable Long id) {
-        return todoRepository.findById(id)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+    public Todo getTodoById(@PathVariable Long id) {
+        return todoService.getTodoById(id);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Todo> updateTodo(@PathVariable Long id, @RequestBody Todo todoDetails) {
-        return todoRepository.findById(id)
-                .map(todo -> {
-                    todo.setTitle(todoDetails.getTitle());
-                    todo.setDescription(todoDetails.getDescription());
-                    todo.setCompleted(todoDetails.isCompleted());
-                    Todo updatedTodo = todoRepository.save(todo);
-                    return ResponseEntity.ok(updatedTodo);
-                })
-                .orElse(ResponseEntity.notFound().build());
+    public Todo updateTodo(@PathVariable Long id, @RequestBody Todo todoDetails) {
+        return todoService.updateTodo(id, todoDetails);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteTodo(@PathVariable Long id) {
-        return todoRepository.findById(id)
-                .map(todo -> {
-                    todoRepository.delete(todo);
-                    return ResponseEntity.ok().build();
-                })
-                .orElse(ResponseEntity.notFound().build());
+        todoService.deleteTodo(id);
+        return ResponseEntity.ok().build();
     }
 
-   
+    @GetMapping("/{id}/download")
+    public ResponseEntity<Resource> downloadTodo(@PathVariable Long id) {
+        return todoService.downloadTodoAsTxt(id);
+    }
+
+    @GetMapping("/download/all")
+    public ResponseEntity<Resource> downloadAllTodos() {
+        return todoService.downloadAllTodosAsTxt();
+    }
 } 

--- a/src/main/java/com/ttn/service/TodoService.java
+++ b/src/main/java/com/ttn/service/TodoService.java
@@ -1,0 +1,104 @@
+package com.ttn.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ttn.common.enums.ErrorCode;
+import com.ttn.common.exception.TTNException;
+import com.ttn.model.Todo;
+import com.ttn.repository.TodoRepository;
+
+@Service
+@Transactional
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+
+    @Autowired
+    public TodoService(TodoRepository todoRepository) {
+        this.todoRepository = todoRepository;
+    }
+
+    public List<Todo> getAllTodos() {
+        return todoRepository.findAll();
+    }
+
+    public Todo createTodo(Todo todo) {
+        if (todo.getTitle() == null || todo.getTitle().trim().isEmpty()) {
+            throw new TTNException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        return todoRepository.save(todo);
+    }
+
+    public Todo getTodoById(Long id) {
+        return todoRepository.findById(id)
+                .orElseThrow(() -> new TTNException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    public Todo updateTodo(Long id, Todo todoDetails) {
+        Todo todo = getTodoById(id);
+        todo.setTitle(todoDetails.getTitle());
+        todo.setDescription(todoDetails.getDescription());
+        todo.setCompleted(todoDetails.isCompleted());
+        return todoRepository.save(todo);
+    }
+
+    public void deleteTodo(Long id) {
+        Todo todo = getTodoById(id);
+        todoRepository.delete(todo);
+    }
+
+    public ResponseEntity<Resource> downloadTodoAsTxt(Long id) {
+        Todo todo = getTodoById(id);
+        
+        StringBuilder content = new StringBuilder();
+        content.append("Title: ").append(todo.getTitle()).append("\n");
+        content.append("Description: ").append(todo.getDescription()).append("\n");
+        content.append("Status: ").append(todo.isCompleted() ? "Completed" : "Pending").append("\n");
+        
+        byte[] contentBytes = content.toString().getBytes(StandardCharsets.UTF_8);
+        ByteArrayResource resource = new ByteArrayResource(contentBytes);
+        
+        String filename = "todo_" + id + ".txt";
+        
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .body(resource);
+    }
+
+    public ResponseEntity<Resource> downloadAllTodosAsTxt() {
+        List<Todo> todos = getAllTodos();
+        if (todos.isEmpty()) {
+            throw new TTNException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        
+        StringBuilder content = new StringBuilder();
+        content.append("All Todos\n\n");
+        
+        todos.forEach(todo -> {
+            content.append("ID: ").append(todo.getId()).append("\n");
+            content.append("Title: ").append(todo.getTitle()).append("\n");
+            content.append("Description: ").append(todo.getDescription()).append("\n");
+            content.append("Status: ").append(todo.isCompleted() ? "Completed" : "Pending").append("\n");
+            content.append("\n");
+        });
+        
+        byte[] contentBytes = content.toString().getBytes(StandardCharsets.UTF_8);
+        ByteArrayResource resource = new ByteArrayResource(contentBytes);
+        
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"all_todos.txt\"")
+                .body(resource);
+    }
+} 


### PR DESCRIPTION
## Description
This PR adds the ability to download todo items as text files, both individually and in bulk.

### Changes Made
- Created `TodoService` class to handle business logic
- Moved existing todo operations from controller to service layer
- Added two new download endpoints:
  - `GET /api/todos/{id}/download`: Downloads a single todo as txt
  - `GET /api/todos/download/all`: Downloads all todos as txt

### Technical Details
- Implemented proper error handling using `TTNException`
- Added input validation
- Used `StringBuilder` for efficient string concatenation
- Proper resource handling with `ByteArrayResource`
- Added transaction management with `@Transactional`

### File Format
Single todo:
```
Title: {todo title}
Description: {todo description}
Status: {Completed/Pending}
```

All todos:
```
All Todos

ID: {id}
Title: {todo title}
Description: {todo description}
Status: {Completed/Pending}

[Next todo...]
```

### Testing
- Endpoints have been tested manually for:
  - Single todo download
  - All todos download
  - Error cases (non-existent todo, empty list)

### Code Quality
- Follows SOLID principles
- Implements proper separation of concerns
- Uses constructor injection for dependencies
- Follows Java best practices